### PR TITLE
novadev-378

### DIFF
--- a/dist/common/types.js
+++ b/dist/common/types.js
@@ -23,6 +23,7 @@ const getMapping = (context) => __awaiter(void 0, void 0, void 0, function* () {
         url: context.environment.url,
         cms: {
             hub: context.hub.name,
+            hubId: context.hub.id,
             stagingApi: ((_b = (_a = context.hub.settings) === null || _a === void 0 ? void 0 : _a.virtualStagingEnvironment) === null || _b === void 0 ? void 0 : _b.hostname) || '',
             imageHub: (_c = context.config) === null || _c === void 0 ? void 0 : _c.cms.imageHub,
             repositories: lodash_1.default.zipObject(lodash_1.default.map(repositories, r => r.name), lodash_1.default.map(repositories, 'id')),

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "homepage": "https://github.com/amplience/dc-demostore-cli#readme",
   "dependencies": {
-    "@amplience/dc-demostore-integration": "github:amplience/dc-demostore-integration#v1.1.1",
+    "@amplience/dc-demostore-integration": "github:amplience/dc-demostore-integration#v1.1.2",
     "@justindfuller/async-lodash": "^1.0.9",
     "@rauschma/stringio": "^1.4.0",
     "adm-zip": "^0.5.9",

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -78,6 +78,7 @@ export const getMapping = async (context: ImportContext): Promise<Mapping> => {
         url: context.environment.url,
         cms: {
             hub: context.hub.name!,
+            hubId: context.hub.id!,
             stagingApi: context.hub.settings?.virtualStagingEnvironment?.hostname || '',
             imageHub: context.config?.cms.imageHub,
             repositories: _.zipObject(_.map(repositories, r => r.name!), _.map(repositories, 'id')),

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -57,6 +57,7 @@ export type Mapping = {
 }
 
 export type CMSMapping = AmplienceConfig & {
+    hubId:                  string
     repositories:           Dictionary<string | undefined>
     workflowStates:         Dictionary<string | undefined>
 }


### PR DESCRIPTION
This update bumps dc-demostore-integration to v1.1.2 and adds the hub ID as a handlebars-accessible value for automation.